### PR TITLE
Fixed flaky testing

### DIFF
--- a/src/test/java/org/vincenzolabs/betadog/controller/ScrapeControllerTest.java
+++ b/src/test/java/org/vincenzolabs/betadog/controller/ScrapeControllerTest.java
@@ -1,6 +1,7 @@
 package org.vincenzolabs.betadog.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,7 @@ import org.vincenzolabs.betadog.service.ScrapeService;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 /**
@@ -101,6 +103,15 @@ class ScrapeControllerTest {
                      .accept(MediaType.APPLICATION_JSON)
                      .exchange()
                      .expectStatus().isOk()
-                     .expectBody(String.class).isEqualTo(objectMapper.writeValueAsString(List.of(air, amp)));
+                     .expectBody(String.class)
+                     .value(body -> {
+                         try {
+                             JsonNode bodyJsonNode = objectMapper.readTree(body);
+                             JsonNode expectedJsonNode = objectMapper.readTree(objectMapper.writeValueAsString(List.of(air, amp)));
+                             assertEquals(expectedJsonNode, bodyJsonNode);
+                         } catch (JsonProcessingException e) {
+                             throw new AssertionError(e);
+                         }
+                     });
     }
 }


### PR DESCRIPTION
### Flakiness
**Nondex** was used to check and locate the flakiness in the test. The test can be reproduced using the following command:
First add 
```
buildscript {
    repositories {
      maven {
        url = uri('https://plugins.gradle.org/m2/')
      }
    }
    dependencies {
      classpath('edu.illinois:plugin:2.1.1')
    }
}
```
to the beginning of `build.gradle` and
```
apply plugin: 'edu.illinois.nondex'
```
at the end of `build.gradle` .
Then replace 
```
test {
  useJUnitPlatform()
}
```
with 
```
tasks.withType(Test) {
  useJUnitPlatform()
}
```
in `build.gradle`.
Then run the following command:
```shell
./gradlew build -x test
./gradlew --info test --testsorg.vincenzolabs.betadog.controller.ScrapeControllerTest.getInstruments
./gradlew --info nondexTest --tests=org.vincenzolabs.betadog.controller.ScrapeControllerTest.getInstruments
``` 

### Issue
The root issue is that `objectMapper.writeValueAsString` use maps to convert json data into strings. In this case the two strings are checked if match to determine the mockResponse has the correct content. However, because map does not guarantee the order of elements returned, the two strings could have the same content but in different order, thus the flakiness. 

## Fix
This flaky test has been fixed through leveraging the Jackson library, which incorporates the JsonNode and ObjectMapper classes. These components are employed for parsing two JSON strings into tree models, which are subsequently compared node by node when assertion is called. 